### PR TITLE
Added the ability to reference a local variable for the live reload script

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,6 @@ module.exports = function(options) {
   options.restartTimeout = options.restartTimeout || 1000;
   options.reloadTimeout = options.reloadTimeout || 500;
   options.watchDirs = options.watchDirs || ['public'];
-  options.app = options.app || {}
   options.checkFunc = options.checkFunc || function(x) {
     return /\.(css|js)$/.test(x);
   };
@@ -113,7 +112,9 @@ module.exports = function(options) {
   var code = '<script>document.write(\'<script src="//\' + (location.host || \'' + options.host + '\').split(\':\')[0] + \':' + options.port + '/livereload.js?snipver=1"></\' + \'script>\')</script>';
   code += '<script>document.addEventListener(\'LiveReloadDisconnect\', function() { setTimeout(function() { window.location.reload(); }, ' + options.reloadTimeout + '); })</script>';
 
-  options.app.locals.LRScript = code
+  if (options.app) {
+    options.app.locals.LRScript = code  
+  }
 
   if (options.restartTimeout > 0) {
     process.on('SIGTERM', function() {

--- a/index.js
+++ b/index.js
@@ -102,6 +102,7 @@ module.exports = function(options) {
   options.restartTimeout = options.restartTimeout || 1000;
   options.reloadTimeout = options.reloadTimeout || 500;
   options.watchDirs = options.watchDirs || ['public'];
+  options.app = options.app || {}
   options.checkFunc = options.checkFunc || function(x) {
     return /\.(css|js)$/.test(x);
   };
@@ -111,6 +112,8 @@ module.exports = function(options) {
 
   var code = '<script>document.write(\'<script src="//\' + (location.host || \'' + options.host + '\').split(\':\')[0] + \':' + options.port + '/livereload.js?snipver=1"></\' + \'script>\')</script>';
   code += '<script>document.addEventListener(\'LiveReloadDisconnect\', function() { setTimeout(function() { window.location.reload(); }, ' + options.reloadTimeout + '); })</script>';
+
+  options.app.locals.LRScript = code
 
   if (options.restartTimeout > 0) {
     process.on('SIGTERM', function() {


### PR DESCRIPTION
I couldn't get this plugin to work with the way I had things setup so I added the ability to pass in `app` to your plugin and just set a local variable under `LRScript`. This way I can access it in my template. It's pretty straight forward and doesn't break anything that's existing.

I updated the `README.md` documenting the addition that I've added. I also updated the typical configuration to make it easier to add multiple file extensions that map to different extensions  and all you have to do is update the `file_type_map` with the extension that's being watched and the extension that you want it to be mapped to. This is what I'm currently running in my app to get stylus middleware and jade templates to work.