### PR TITLE
change dependency path

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ function startLRServer(options) {
   });
 
   lrserver.on('livereload.js', function(req, res) {
-    fs.readFile(path.join(__dirname, 'node_modules', 'livereload-js', 'dist', 'livereload.js'), 'utf8', function(err, data) {
+    fs.readFile(path.join(require.resolve('livereload-js'), '../../', 'dist', 'livereload.js'), 'utf8', function(err, data) {
       if (err) throw err;
       res.writeHead(200, {
         'Content-Length': data.length,


### PR DESCRIPTION
If using nmp 3, I get the following error:

    node_modules/easy-livereload/index.js:52
      if (err) throw err;
               ^

    Error: ENOENT: no such file or directory, open '/home/jozzhart/Development/express/app/node_modules/easy-livereload/node_modules/livereload-js/dist/livereload.js'
    at Error (native)

Not sure if this is the best way to resolve the issue, but I am unaware of a better way to get the actual module path for the dependency.