### PR TITLE
Modifies the LRWebSocketServer prototype to listen for errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,14 @@ var bodyRewrite = require('connect-body-rewrite');
 
 var lrserver = null;
 
+var orgCreateConnection = LRWebSocketServer.prototype._createConnection;
+LRWebSocketServer.prototype._createConnection = function(socket) {
+  orgCreateConnection.call(this, socket);
+  socket.on('error', function(err) {
+    return console.error(err);
+  });
+};
+
 function startLRServer(options) {
   if (lrserver) return;
 


### PR DESCRIPTION
- Listens for error events on the websocket instance to avoid uncaught
ECONNRESET exceptions.

When no listener is attached to error event from the websocket - the
ECONNRESET expception is thrown: https://github.com/websockets/ws/issues/1256

This is also somewhat relevant:
https://github.com/livereload/livereload-server/pull/2