### PR TITLE
Update node-watch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "connect-body-rewrite": "0.0.4",
     "livereload-js": "^2.2.2",
     "livereload-server": "^0.2.3",
-    "node-watch": "^0.3.5"
+    "node-watch": "^0.6.4"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
In my express project, `easy-livereload` fails to instanciate on Node v14 with this error:
```
[ERR_FEATURE_UNAVAILABLE_ON_PLATFORM]: The feature watch recursively is unavailable on the current platform, which is being used to run Node.js
```
Updating `node-watch` should get rid of it.