### PR TITLE
Fix node-watch usage after update (parameters for callback changed)

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function startLRServer(options) {
   };
 
   options.watchDirs.forEach(function(dir) {
-    watch(dir, function(file) {
+    watch(dir, function(event, file) {
       file = path.relative(dir, file);
       if (options.checkFunc(file)) {
         sendAll({


### PR DESCRIPTION
Callback parameters have changed, `file` isn't the first parameter anymore (as seen in the readme here: https://github.com/yuanchuan/node-watch).
So `easy-livereload` with the latest `node-watch` doesn't actually work properly now after yesterday's update.

Here's a fix for it.

So sorry about that, there was a deprecation warning but I didn't pay attention to it. Oh well...